### PR TITLE
Improved readability of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,27 @@
 ### Cfn2dsl
 
-cfn2dsl is a tool to enable CloudFormation development team to work on both JSON templates and Ruby DSL code written in `cfndsl` (created by project [cfndsl](https://github.com/stevenjack/cfndsl])).
+cfn2dsl is a tool to enable CloudFormation development teams to work with both JSON templates and Ruby DSL code written in `cfndsl` (created by [cfndsl](https://github.com/stevenjack/cfndsl]) project).
 
-The idea is to give developer options on developing CloudFormation using the tool and language they feel comfortable and efficient. Some developers like to develop JSON template, and others like to develop with `cfndsl`. We need a tool to sync the developments on both methods, so `cfn2dsl` is here to help. It can parse CloudFormation JSON templates and translate them into `cfndsl` Ruby DSL.
+The idea is to give developers options for developing CloudFormation configurations using the tool and language which they feel comfortable and efficient in. Some developers like to develop JSON templates, and others like to develop with `cfndsl`. We need a tool to synchronise development in both methods, so `cfn2dsl` is here to help. It can parse CloudFormation JSON templates and translate them into `cfndsl`'s Ruby DSL.
 
 #### what cfn2dsl can do
 
 
-* it parse CloudFormation JSON template and output `cfndsl` Ruby code
+* It parses CloudFormation JSON template and outputs `cfndsl` Ruby code.
 
-* it use generic `cfndsl` objects in the translation, for example `Parameter()`, `Resource()`, `Output()` and `Property()`. It supports all official resources, attributes and properties supported by CloudFormation.
+* It uses generic `cfndsl` objects in the translation, for example `Parameter()`, `Resource()`, `Output()` and `Property()`. It supports all the resources, attributes and properties officially supported by CloudFormation.
 
-* it formats ruby hash/arry objects in a more readable way using `awesome_print`
+* It formats Ruby hash/array objects in a more readable way using `awesome_print`.
 
 #### what cfn2dsl can't do
 
-* it is not able to keep your comments in Ruby code, you might need to move the important information out from the Ruby code into README.md
+* It is not able to keep your comments in the Ruby source, so you might need to move any important information that exists in comments out from the Ruby code into a README file.
 
-* it so far doesn't know how to translate CloudForamtion resource into abstracted objects used in `cfndsl`, for example `EC2_Instance` ...
+* It currently doesn't know how to translate CloudForamtion resource into the abstracted objects used in `cfndsl`, for example `EC2_Instance`.
 
-* it can't reproduce your programming logic in your `cfndsl` template if you rely on Ruby code to do interesting things, for example environment variables. (you might think about to use CloudFormation Conditions to achieve environment switch)
+* It can't reproduce your programming logic in your `cfndsl` template if you rely on Ruby code to do interesting things, for example environment variables. (You might need to think about using CloudFormation Conditions to achieve an environment switch.)
 
-* it doesn't know the translation of special intrinsic function provides by `cfndsl`, for example `FnFormat()`
+* It doesn't know how to translate special intrinsic functionality provided by `cfndsl`, for example `FnFormat()`.
 
 
 #### how to use this tool
@@ -30,7 +30,7 @@ The idea is to give developer options on developing CloudFormation using the too
 #> gem install cfn2dsl
 ```
 
-* command line options
+* Command line options
 
 ```
 #> cfn2dsl --help
@@ -41,18 +41,14 @@ Usage: cfn2dsl -t|--template file [-o|--output file]
     -h, --help                       show this message
 ```
 
-* translate JSON template and output to standard out
+* Translate JSON template and send output to standard output
 
 ```
 cfn2dsl -t /your/path/to/template.json
 ```
 
-* translate JSON template and write output to file
+* Translate JSON template and write output to file
 
 ```
 cfn2dsl -t /your/path/to/template.json -o /your/path/to/template.rb
 ```
-
-
-
-


### PR DESCRIPTION
:information_desk_person: Some text in the original README document didn't make sense as sentences. I've attempted to update them as minimally as possible in order to maintain the original prose.

I've also made some changes for consistency, e.g. starting unordered lists with capital letters using title case and ending them with full stops.
