### PR TITLE
Update metadata support

### DIFF
--- a/lib/cfndsl.erb
+++ b/lib/cfndsl.erb
@@ -135,7 +135,7 @@ CloudFormation do
           value = value.ai
         end
     %>
-    Metadata(<%= name.dump %>, <%= value %>)
+    Metadata(<%= name.dump %> => <%= value %>)
     <%
       end
     end


### PR DESCRIPTION
As cfndsl now requires Metadata to be a JSONable object, metadata needs a simple update from , to =>. Tested and confirmed working with latest version of cfndsl.

See the parent issue here: https://github.com/stevenjack/cfndsl/issues/227 